### PR TITLE
Workaround for issue "frus-history research section" #62

### DIFF
--- a/modules/ext-html.xql
+++ b/modules/ext-html.xql
@@ -45,7 +45,11 @@ declare function pmf:ref($config as map(*), $node as element(), $class as xs:str
     let $docName := util:collection-name($node)
     let $publication-id := $hsg-config:PUBLICATION-COLLECTIONS?($docName)
     let $document-id := substring-before(util:document-name($node), '.xml')
-    let $target := $node/@target
+
+    (: ToDO: Quick fix not sure where the origin is from :)
+    let $tmp := data($node/@target)
+    let $target := if (starts-with($tmp, '/')) then $tmp else ("/" || $tmp)
+    
     let $href := 
         (: generic: catch http, mailto links :)
         if (matches($target, '^http|mailto')) then


### PR DESCRIPTION
Workaround for https://github.com/eXistSolutions/hsg-shell/issues/62

Not sure how to actually repair it, but for sure $target should start with "/" just like all other patterns that come in. Might be a data issue.

now the result looks like:

![search_list](https://cloud.githubusercontent.com/assets/1700062/12377300/22515b6e-bd19-11e5-9352-c92f0bd87283.gif)

