### PR TITLE
fix(style): Add table-cell padding for default TEI tables #125

### DIFF
--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -7,3 +7,8 @@
 .tei-titleStmt4 li {
   margin-bottom: 0;
 }
+
+.tei-table1 .tei-cell {
+  padding: 8px;
+  line-height: 1.42857;
+}


### PR DESCRIPTION
Additional fix:
Apply bootstrap-like cell-spacing and line-height to TEI tables containing class "tei-table1" (which isn't used yet).