### PR TITLE
fix(style): Override wrong hard coded image attributes #115

### DIFF
--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -12,3 +12,12 @@
   padding: 8px;
   line-height: 1.42857;
 }
+
+.tei-div3 {
+  .tei-figure2 {
+    img {
+      width: auto !important;
+      height: auto !important;
+    }
+  }
+}


### PR DESCRIPTION
This is a quick fix and should be replaced by a general templating rule
for images concerning their width and height value.
The aim here is to override inline styles coming from the TEI content
file.

Fixes #115 