### PR TITLE
Fix image size

### DIFF
--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -12,12 +12,3 @@
   padding: 8px;
   line-height: 1.42857;
 }
-
-.tei-div3 {
-  .tei-figure2 {
-    img {
-      width: auto !important;
-      height: auto !important;
-    }
-  }
-}

--- a/resources/odd/compiled/frus.odd
+++ b/resources/odd/compiled/frus.odd
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:frus="http://history.state.gov/frus/ns/1.0" xml:lang="en">
     <teiHeader>
         <fileDesc>
@@ -299,8 +298,6 @@ display: block;
                 <model behaviour="graphic">
                     <param name="url">xs:anyURI('//s3.amazonaws.com/static.history.state.gov/' || $parameters?base-uri || 
                             "/" || @url || (if (matches(@url, "^.*\.(jpg|png|gif)$")) then "" else ".png"))</param>
-                    <param name="width">@width</param>
-                    <param name="height">@height</param>
                     <param name="scale">@scale</param>
                     <param name="title">desc</param>
                 </model>

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -271,8 +271,6 @@
                     <model behaviour="graphic">
                         <param name="url">xs:anyURI('//s3.amazonaws.com/static.history.state.gov/' || $parameters?base-uri || 
                             "/" || @url || (if (matches(@url, "^.*\.(jpg|png|gif)$")) then "" else ".png"))</param>
-                        <param name="width">@width</param>
-                        <param name="height">@height</param>
                         <param name="scale">@scale</param>
                         <param name="title">desc</param>
                     </model>


### PR DESCRIPTION
* Delete width and height for frus-images from odd.
This prevents images from being displayed in wrong ratios, when given incorrect width and height values as inline styles in the TEI.
Fixes #115

* Delete css hotfix for overriding inline image attributes
  Reverts previous fix for issue #115

* TODO: Store the images size as metadata and use them to set width and height dynamically, because these attributes are important for valid markup.