### PR TITLE
Fix spacing in frus lists #123

### DIFF
--- a/resources/odd/compiled/frus-web.xql
+++ b/resources/odd/compiled/frus-web.xql
@@ -230,7 +230,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                             html:inline($config, ., ("tei-gap3"), .)
                 case element(graphic) return
                     html:graphic($config, ., ("tei-graphic"), ., xs:anyURI('//s3.amazonaws.com/static.history.state.gov/' || $parameters?base-uri || 
-                            "/" || @url || (if (matches(@url, "^.*\.(jpg|png|gif)$")) then "" else ".png")), @width, @height, @scale, desc)
+                            "/" || @url || (if (matches(@url, "^.*\.(jpg|png|gif)$")) then "" else ".png")), (), (), @scale, desc)
                 case element(group) return
                     html:block($config, ., ("tei-group"), .)
                 case element(handShift) return

--- a/resources/odd/compiled/frus-web.xql
+++ b/resources/odd/compiled/frus-web.xql
@@ -301,10 +301,14 @@ declare function model:apply($config as map(*), $input as node()*) {
                             if (@type = ('participants', 'to', 'from', 'subject')) then
                                 html:list($config, ., ("tei-list2"), item)
                             else
-                                if (label) then
-                                    html:list($config, ., ("tei-list3", "labeled-list"), item)
+                                if (parent::list/@type = ('participants', 'to', 'from', 'subject')) then
+                                    (: This is a nested list within a list-item :)
+                                    html:list($config, ., ("tei-list3"), item)
                                 else
-                                    html:list($config, ., ("tei-list4", "list"), item)
+                                    if (label) then
+                                        html:list($config, ., ("tei-list4", "labeled-list"), item)
+                                    else
+                                        html:list($config, ., ("tei-list5", "list"), item)
                 case element(listBibl) return
                     if (bibl) then
                         html:list($config, ., ("tei-listBibl1"), bibl)

--- a/resources/odd/compiled/frus.css
+++ b/resources/odd/compiled/frus.css
@@ -78,7 +78,8 @@
 .tei-list2 { list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0 }
 .tei-list3 { list-style-type: disc; }
 .tei-list4 { list-style-type: none; }
-.tei-list6 { list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0 }
+.tei-list5 { list-style-type: none; margin-top: 1em; }
+.tei-list7 { list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0 }
 .tei-note1 { font-size: smaller; }
 .tei-p1 { text-align: center; }
 .tei-p2 { text-indent: 0em; }

--- a/resources/odd/compiled/frus.css
+++ b/resources/odd/compiled/frus.css
@@ -77,7 +77,7 @@
 .tei-l { margin-left: 1em; }
 .tei-list2 { list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0 }
 .tei-list3 { list-style-type: disc; }
-.tei-list4 { list-style-type: none; line-height: 1.3em; }
+.tei-list4 { list-style-type: none; }
 .tei-list6 { list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0 }
 .tei-note1 { font-size: smaller; }
 .tei-p1 { text-align: center; }

--- a/resources/odd/compiled/frus.odd
+++ b/resources/odd/compiled/frus.odd
@@ -385,7 +385,7 @@ display: block;
                 </model>
                 <model predicate="@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
                     <param name="content">item</param>
-                    <outputRendition>list-style-type: none; line-height: 1.3em;</outputRendition>
+                    <outputRendition>list-style-type: none;</outputRendition>
                 </model>
                 <model predicate="label" behaviour="list" cssClass="labeled-list">
                     <param name="content">item</param>

--- a/resources/odd/compiled/frus.odd
+++ b/resources/odd/compiled/frus.odd
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:frus="http://history.state.gov/frus/ns/1.0" xml:lang="en">
     <teiHeader>
         <fileDesc>

--- a/resources/odd/compiled/frus.odd
+++ b/resources/odd/compiled/frus.odd
@@ -387,6 +387,11 @@ display: block;
                     <param name="content">item</param>
                     <outputRendition>list-style-type: none;</outputRendition>
                 </model>
+                <model predicate="parent::list/@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
+                    <param name="content">item</param>
+                    <desc>This is a nested list within a list-item</desc>
+                    <outputRendition>list-style-type: none; margin-top: 1em;</outputRendition>
+                </model>
                 <model predicate="label" behaviour="list" cssClass="labeled-list">
                     <param name="content">item</param>
                 </model>

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -179,7 +179,7 @@
                     </model>
                     <model predicate="@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
                         <param name="content">item</param>
-                        <outputRendition>list-style-type: none; line-height: 1.3em;</outputRendition>
+                        <outputRendition>list-style-type: none;</outputRendition>
                     </model>
                     <model predicate="label" behaviour="list" cssClass="labeled-list">
                         <param name="content">item</param>

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -181,6 +181,11 @@
                         <param name="content">item</param>
                         <outputRendition>list-style-type: none;</outputRendition>
                     </model>
+                    <model predicate="parent::list/@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
+                        <param name="content">item</param>
+                        <desc>This is a nested list within a list-item</desc>
+                        <outputRendition>list-style-type: none; margin-top: 1em;</outputRendition>
+                    </model>
                     <model predicate="label" behaviour="list" cssClass="labeled-list">
                         <param name="content">item</param>
                     </model>


### PR DESCRIPTION
I'm not sure, if I fixed this issue right, because I made my changes in odd lines with containing the tag `<outputRendition>`. Does this tag contain rendition styles, which must be explicitly set here?
What I did is just deleted the style `line-height: 1.3em`, so that the lines are inheriting the correct line-height from the parent-element now.

`resources/odd/source/frus.odd` in line 182:
```
 <model predicate="@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
      <param name="content">item</param>
      <outputRendition>list-style-type: none;</outputRendition>
 </model>
```
Fixes #123