### PR TITLE
use gulp-exist v1.2.1 from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "del": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
-    "gulp-exist": "git+https://github.com/line-o/gulp-exist.git",
+    "gulp-exist": "^1.2,1",
     "gulp-imagemin": "^2.4.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",


### PR DESCRIPTION
When https://www.npmjs.com/package/gulp-exist is updated to at least 1.2.1 merge this PR!