### PR TITLE
Apply style guide compliant colors to navbar and fix spacing of menu items

### DIFF
--- a/app/scss/_customized-bootstrap.scss
+++ b/app/scss/_customized-bootstrap.scss
@@ -39,23 +39,15 @@ $icon-font-path: "../fonts/";
 /* Navbar ------------- */
 
 .navbar {
-  //background: #2c6196;
-  background: $bg-color-navbar;
-  border-color: $bg-color-navbar;
   padding: 0;
-  color: white;
   margin-bottom: 0;
   min-height: 37px;
   border-radius: 0;
-}
-
-.navbar .container-fluid {
-  height: 37px;
-}
-
-.navbar li, .navbar span {
-  font-family: $font-sans;
-  margin-bottom: 0;
+  border: none;
+  li, span {
+    font-family: $font-sans;
+    margin-bottom: 0;
+  }
 }
 
 .navbar-inner {
@@ -63,77 +55,79 @@ $icon-font-path: "../fonts/";
 }
 
 .nav {
-  margin-top: -2px;
-
-  @media (min-width: 768px) and (max-width: 991px){
+  @media (min-width: $grid-float-breakpoint) and (max-width: 991px){
     font-size: $small-font-size;
-   > li > a {
-     padding: 10px 14px;
-   }
+    > li > a {
+      padding: 10px 14px;
+    }
   }
 }
 
-/*
-.nav > li > a {
-  @media (min-width: 768px) and (max-width: 991px) {
-    padding: 10px 14px;
+.navbar-default {
+  .navbar-nav {
+    margin: 0 -15px;
+    > li > a {
+      color: $dropdown-link-color;
+      transition: color 0s;
+
+      @media (min-width: $grid-float-breakpoint) {
+        color: $navbar-default-link-color;
+        padding-top: 10px;
+        padding-bottom: 10px;
+      }
+    }
+
+    > .open {
+      > a,
+      > a:focus {
+        color: $navbar-default-link-color;
+      }
+    }
+
+    .open .dropdown-menu {
+      li {
+        padding-left: 0;
+      }
+      > li > a {
+        @media (max-width: $grid-float-breakpoint-max) {
+          color: $dropdown-link-color;
+          transition: color 0s;
+          line-height: 2em;
+          padding-left: 2.2em;
+        }
+      }
+    }
+    .dropdown-menu {
+      padding-top: 0;
+      padding-bottom: 0;
+      font-size: $small-font-size;
+      a {
+        line-height: 2em;
+      }
+    }
   }
-}
-*/
-
-.navbar-brand,
-.navbar-nav li a {
-  height: 37px;
-  line-height: 37px;
-  padding-top: 0;
-  color: $color-white;
-}
-
-.mavbar-default .navbar-nav > .dropdown.open a {
-    background: transparent;
-    color: #000066;
-}
-
-.navbar-default .navbar-nav > .dropdown.open .dropdown-menu a:hover {
-  background-color: #f3f3f3;
 }
 
 .navbar-collapse {
   padding-left: 0;
+  @media (max-width: 767px) {
+    background-color: $color-cool-blue-lightest;
+    color: $color-base;
+  }
 }
 
 .navbar-toggle {
   padding: 6px 10px;
   margin: 6px 12px;
+  color: $navbar-default-color;
   &:hover {
-    color: #030361;
+    color: $navbar-default-link-hover-color;
   }
-}
-
-.dropdown-menu,
-.collapsing,
-.collapse.in {
-  background-color: #dddde8;
-}
-
-.navbar .collapse.in li,
-.navbar .collapsing li {
-  background: #2c6196;
-}
-
-.navbar .dropdown.open .dropdown-menu li {
-  background-color: #dddde8;
-  padding-left: 0;
-}
-
-.navbar .dropdown.open .dropdown-menu li a {
-  color: #030361;
 }
 
 .collapsing li,
 .collapse.in li {
-  padding-left: 10px;
-  color: #000066;
+  padding-left: 15px;
 }
 
 /* Table -------------- */

--- a/app/scss/_ribbon.scss
+++ b/app/scss/_ribbon.scss
@@ -8,7 +8,6 @@
     overflow: hidden;
     width: 200px;
     height: 200px;
-    z-index: 1000;
   }
 }
 

--- a/app/scss/_search.scss
+++ b/app/scss/_search.scss
@@ -26,6 +26,7 @@
   position: absolute;
   top: 1px;
   right: 1px;
+  z-index: 1;
   border: none !important;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -76,10 +76,6 @@ $color-cool-blue-lightest:   #dce4ef; // lighten($color-cool-blue, 90%)
 $color-focus:                #3e94cf;
 $color-visited:              #4c2c92;
 
-// Navigation backgroundcolor
-$bg-color-navbar:            $color-primary-darker;
-
-
 // Mobile First Breakpoints
 $xs-screen:         481px;
 $small-screen:      601px;
@@ -106,3 +102,26 @@ $default-border-style: 1px solid $color-gray-lighter; // was #dddde8
 
 // Margins
 $margin-vertical-base: .53em;
+
+// Bootstrap Variables
+
+$navbar-default-color:                $color-white;
+$navbar-default-bg:                   $color-primary-darker;
+$navbar-default-border:               $color-primary-darker;
+
+$navbar-default-link-color:           $color-white;
+$navbar-default-link-hover-color:     $color-white;
+$navbar-default-link-hover-bg:        $color-cool-blue-light;
+$navbar-default-link-active-color:    $color-cool-blue-lightest;
+$navbar-default-link-active-bg:       $color-primary-darkest;
+$navbar-default-link-disabled-color:  $color-gray-warm-dark;
+
+$navbar-default-toggle-border-color:  $color-white;
+$navbar-default-toggle-hover-bg:      $color-primary-darkest;
+$navbar-default-toggle-icon-bar-bg:   $color-white;
+
+$dropdown-bg:                         $color-white;
+$dropdown-link-color:                 $color-base;
+$dropdown-link-hover-bg:              $color-cool-blue-lightest;
+$dropdown-link-active-bg:             $color-primary-darker;
+$dropdown-link-disabled-color:        $color-gray-warm-dark;

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -1,5 +1,6 @@
 @charset "UTF-8";
 
+@import "variables";
 
 // Vendor -------------- //
 
@@ -10,7 +11,6 @@
 
 // Core ---------------- //
 
-@import "variables";
 @import "base";
 @import "customized-bootstrap";
 

--- a/templates/site.html
+++ b/templates/site.html
@@ -51,14 +51,14 @@
                 </div>
                 <div class="navbar-collapse collapse" id="navbar-collapse-1">
                     <ul class="nav navbar-nav">
-                        <li>
+                        <li class="dropdown">
                             <a href="$app/" shape="rect">
-                                <span style="color: white">Home</span>
+                                <span>Home</span>
                             </a>
                         </li>
                         <li class="dropdown">
                             <a href="$app/historicaldocuments" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span style="color: white">Historical Documents</span>
+                                <span>Historical Documents</span>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
@@ -82,7 +82,7 @@
                         </li>
                         <li id="index_nav" class="dropdown">
                             <a href="$app/departmenthistory" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span style="color: white">Department History</span>
+                                <span>Department History</span>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
@@ -118,7 +118,7 @@
                         </li>
                         <li id="milestones_nav" class="dropdown">
                             <a href="$app/milestones" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span style="color: white">Key Milestones</span>
+                                <span>Key Milestones</span>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
@@ -185,7 +185,7 @@
                         </li>
                         <li id="countries_nav" class="dropdown">
                             <a href="$app/countries" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span style="color: white">Guide to Countries</span>
+                                <span>Guide to Countries</span>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>
@@ -198,7 +198,7 @@
                         </li>
                         <li id="resources_nav" class="dropdown">
                             <a href="" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span style="color: white">More Resources</span>
+                                <span>More Resources</span>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>


### PR DESCRIPTION
* Apply style guide compliant colors to navbar
    - refactor navbar styles
   - delete obsolete styles
   - remove unnecessary margins
   - add more space to dropdown-menu items for easier selection on touch
devices
* Reorder z-indices of ribbon and search box , because the ribbon container was lying over the last menu item on certain screen widths, so it couldn’t be selected.
* Delete inline styles from site template
* Set custom bootstrap variables for navbar colors

**Desktop:**

<img width="948" alt="desktop-navbar" src="https://cloud.githubusercontent.com/assets/1157669/13685392/8885ca02-e710-11e5-95dd-2787e377f5bc.png">

---
**Tablet:**

<img width="339" alt="tablet-nav" src="https://cloud.githubusercontent.com/assets/1157669/13685250/bea8bfbe-e70f-11e5-8c93-3e7f2ae7d3d3.png">

---
**Mobile:**
<img width="339" alt="mobile-nav" src="https://cloud.githubusercontent.com/assets/1157669/13685267/d0690bdc-e70f-11e5-8fe1-01c958f3eec5.png">

---

**In comparison the current navbar on beta view:**

<img width="339" alt="old-nav" src="https://cloud.githubusercontent.com/assets/1157669/13685333/3aadfebc-e710-11e5-9bb9-c9288d68dc3e.png">
---
<img width="441" alt="old-mobile-nav" src="https://cloud.githubusercontent.com/assets/1157669/13685344/487a43de-e710-11e5-8aec-0c252a0cab0f.png">
